### PR TITLE
Add support for Enchantment Descriptions.

### DIFF
--- a/Common/src/main/resources/assets/netherited/lang/en_us.json
+++ b/Common/src/main/resources/assets/netherited/lang/en_us.json
@@ -1,3 +1,4 @@
 {
-  "enchantment.netherited.fireproof": "Fireproof"
+  "enchantment.netherited.fireproof": "Fireproof",
+  "enchantment.netherited.fireproof.desc": "Prevents the item from being burned."
 }


### PR DESCRIPTION
Hello, this PR adds support for mods that attempt to display a description of an enchantment such as [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions). 